### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -1,4 +1,8 @@
 name: Update versions
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Robin-Gryncewicz/Robin-Gryncewicz/security/code-scanning/2](https://github.com/Robin-Gryncewicz/Robin-Gryncewicz/security/code-scanning/2)

To fix the problem, add a top-level `permissions` key to the workflow, specifying the minimal required permissions. Place it near the top of the file, after the `name:` declaration and before the `on:` block for clarity. The correct settings for this workflow require `contents: write` (for branch creation/committing/pushing), `pull-requests: write` (for creating PRs), and `issues: write` (for labeling PRs via the API). This restricts the `GITHUB_TOKEN` permissions to only what is needed, not the repository defaults. No changes are needed elsewhere in the file, only this block added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
