### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/achievement-helper.yml
+++ b/.github/workflows/achievement-helper.yml
@@ -1,4 +1,6 @@
 name: Achievement Helper
+permissions:
+  contents: read
 
 # This is an EXAMPLE workflow to demonstrate how automation can help with achievements
 # To use this, rename to achievement-helper.yml and customize as needed


### PR DESCRIPTION
Potential fix for [https://github.com/Robin-Gryncewicz/Robin-Gryncewicz/security/code-scanning/5](https://github.com/Robin-Gryncewicz/Robin-Gryncewicz/security/code-scanning/5)

To fix this problem, add an explicit `permissions` block at the top of the workflow file, immediately following the workflow `name:` and before the `on:` key. Set permissions to the least privilege required. For this workflow, most jobs only need read access to the repository contents and optionally to pull requests or issues. Since none of the enabled jobs modify repository contents (and the comment on making a PR is only present, not run), the minimal starting point is:

```yaml
permissions:
  contents: read
```

This should be placed after the `name:` at the top of `.github/workflows/achievement-helper.yml`. If later jobs need write access to issues or pull requests, you can add them as needed for those jobs.  

**What to change:**  
- Insert the recommended `permissions:` block (with `contents: read`) directly below the workflow `name:` (line 1), so it applies to all jobs unless overridden.
- No additional imports, methods, or definitions required for YAML workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
